### PR TITLE
fix: Handle editor launch when path contains spaces on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## [Unreleased]
+
+### Fixed
+
+- Editor commands with spaces in the path (e.g. `'C:/Program Files/…/emacs.exe'
+  --no-splash`) are now parsed correctly as shell words. Previously, naive
+  whitespace splitting broke the executable path, silently preventing the editor
+  from launching on Windows.
+
+
 ## [0.3.0] - 2026-04-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "insta",
  "ratatui",
  "regex",
+ "shell-words",
  "tempfile",
  "time",
 ]
@@ -1415,6 +1416,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4", default-features = false, features = ["std", "derive", "
 time = { version = "0.3", default-features = false, features = ["formatting", "macros"] }
 tempfile = "3"
 regex = { version = "1", default-features = false, features = ["std", "perf", "unicode-perl", "unicode-case"] }
+shell-words = "1"
 
 [dev-dependencies]
 insta = "1"

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -52,18 +52,20 @@ fn resolve_editor(repo: &impl GitRepo) -> String {
 /// never left in a broken state.
 fn launch_editor(repo: &impl GitRepo, path: &std::path::Path) -> anyhow::Result<()> {
     let editor_cmd = resolve_editor(repo);
-    let mut parts = editor_cmd.split_whitespace();
-    let prog = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("editor command is empty"))?;
-    let args: Vec<&str> = parts.collect();
+    let mut parts = shell_words::split(&editor_cmd)
+        .with_context(|| format!("failed to parse editor command `{editor_cmd}`"))?;
+    if parts.is_empty() {
+        anyhow::bail!("editor command is empty");
+    }
+    let prog = parts.remove(0);
+    let args = parts;
 
     // Suspend TUI before handing the terminal to the editor.
     terminal::disable_raw_mode().context("failed to disable raw mode")?;
     execute!(std::io::stdout(), terminal::LeaveAlternateScreen)
         .context("failed to leave alternate screen")?;
 
-    let status = std::process::Command::new(prog)
+    let status = std::process::Command::new(&prog)
         .args(&args)
         .arg(path)
         .status();


### PR DESCRIPTION
Editor commands like "'C:/Program Files/.../emacs.exe' --no-splash" were split on whitespace, making the executable path invalid. Switch to shell_words::split() to handle quoted tokens correctly.