### PR TITLE
fix: launch merge tool directly without sh, substitute vars in Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on
   --no-splash`) are now parsed correctly as shell words. Previously, naive
   whitespace splitting broke the executable path, silently preventing the editor
   from launching on Windows.
+- Merge tool commands are now launched directly without a shell, with
+  `$LOCAL`/`$BASE`/`$REMOTE`/`$MERGED` substituted in Rust. This fixes launch
+  failures on Windows (no `sh`) and correctly handles tool paths that contain
+  spaces.
 
 
 ## [0.3.0] - 2026-04-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on
   `$LOCAL`/`$BASE`/`$REMOTE`/`$MERGED` substituted in Rust. This fixes launch
   failures on Windows (no `sh`) and correctly handles tool paths that contain
   spaces.
+- After returning from an external editor or merge tool, Enter, Esc, and arrow
+  keys no longer stop working. The TUI suspend/restore now correctly re-pushes
+  keyboard-enhancement flags and uses the right terminal handle on all
+  platforms.
 
 
 ## [0.3.0] - 2026-04-03

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -15,7 +15,6 @@
 use crate::repo::GitRepo;
 
 use anyhow::Context as _;
-use crossterm::{execute, terminal};
 
 /// Resolve the editor command to use for editing commit messages.
 ///
@@ -60,21 +59,11 @@ fn launch_editor(repo: &impl GitRepo, path: &std::path::Path) -> anyhow::Result<
     let prog = parts.remove(0);
     let args = parts;
 
-    // Suspend TUI before handing the terminal to the editor.
-    terminal::disable_raw_mode().context("failed to disable raw mode")?;
-    execute!(std::io::stdout(), terminal::LeaveAlternateScreen)
-        .context("failed to leave alternate screen")?;
-
     let status = std::process::Command::new(&prog)
         .args(&args)
         .arg(path)
-        .status();
-
-    // Restore TUI unconditionally so the app is never left in a broken state.
-    let _ = terminal::enable_raw_mode();
-    let _ = execute!(std::io::stdout(), terminal::EnterAlternateScreen);
-
-    let status = status.with_context(|| format!("failed to launch editor `{prog}`"))?;
+        .status()
+        .with_context(|| format!("failed to launch editor `{prog}`"))?;
     if !status.success() {
         anyhow::bail!("editor exited with {status}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,33 @@ struct Cli {
 /// changes) whose diff cannot be fetched by OID. They are appended at the end
 /// of the regular commit diffs so the fragmap matrix rows match the ordering in
 /// `AppState::commits`.
+/// Suspend the TUI, run `f`, then restore the TUI unconditionally.
+///
+/// Undoes the full setup done in `main` before calling `f` (leaves alternate
+/// screen, disables raw mode, pops keyboard-enhancement flags), then mirrors
+/// each step in reverse so the TUI is always left in a working state.
+/// Re-pushing `DISAMBIGUATE_ESCAPE_CODES` is critical on Windows: without it
+/// keys like Enter, Esc, and arrows stop working after the external process exits.
+fn with_external_process<T>(kb_enhanced: bool, f: impl FnOnce() -> T) -> T {
+    if kb_enhanced {
+        let _ = execute!(io::stderr(), PopKeyboardEnhancementFlags);
+    }
+    let _ = disable_raw_mode();
+    let _ = execute!(io::stderr(), LeaveAlternateScreen);
+
+    let result = f();
+
+    let _ = execute!(io::stderr(), EnterAlternateScreen);
+    let _ = enable_raw_mode();
+    if kb_enhanced {
+        let _ = execute!(
+            io::stderr(),
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        );
+    }
+    result
+}
+
 fn compute_fragmap(
     git_repo: &impl GitRepo,
     regular_commits: &[CommitInfo],
@@ -371,7 +398,9 @@ fn main() -> Result<()> {
                         ctx.combined_message.clone()
                     } else {
                         let combined = ctx.combined_message.clone();
-                        let editor_result = editor::edit_message_in_editor(&git_repo, &combined);
+                        let editor_result = with_external_process(kb_enhanced, || {
+                            editor::edit_message_in_editor(&git_repo, &combined)
+                        });
                         terminal.clear()?;
                         match editor_result {
                             Err(e) => {
@@ -446,7 +475,9 @@ fn main() -> Result<()> {
                 files,
                 conflict_state,
             } => {
-                let result = mergetool::run_mergetool(&git_repo, &files);
+                let result = with_external_process(kb_enhanced, || {
+                    mergetool::run_mergetool(&git_repo, &files)
+                });
                 terminal.clear()?;
                 match result {
                     Ok(true) => {
@@ -476,14 +507,14 @@ fn main() -> Result<()> {
                 conflict_state,
             } => {
                 let workdir = git_repo.workdir();
-                let result: anyhow::Result<()> = (|| {
+                let result: anyhow::Result<()> = with_external_process(kb_enhanced, || {
                     let workdir = workdir
                         .ok_or_else(|| anyhow::anyhow!("repository has no working directory"))?;
                     for file_path in &files {
                         editor::open_file_in_editor(&git_repo, &workdir.join(file_path))?;
                     }
                     Ok(())
-                })();
+                });
                 terminal.clear()?;
                 match result {
                     Ok(()) => {
@@ -514,7 +545,9 @@ fn main() -> Result<()> {
                         continue;
                     }
                 };
-                let editor_result = editor::edit_message_in_editor(&git_repo, &current_message);
+                let editor_result = with_external_process(kb_enhanced, || {
+                    editor::edit_message_in_editor(&git_repo, &current_message)
+                });
                 terminal.clear()?;
                 match editor_result {
                     Err(e) => app.set_error_message(format!("Editor error: {e}")),
@@ -582,7 +615,9 @@ fn main() -> Result<()> {
                 let final_message = if is_fixup {
                     Some(target_message)
                 } else {
-                    let editor_result = editor::edit_message_in_editor(&git_repo, &combined);
+                    let editor_result = with_external_process(kb_enhanced, || {
+                        editor::edit_message_in_editor(&git_repo, &combined)
+                    });
                     terminal.clear()?;
                     match editor_result {
                         Err(e) => {

--- a/src/mergetool.rs
+++ b/src/mergetool.rs
@@ -22,7 +22,8 @@
 //   - git runs the cmd through a shell and waits for it to exit
 //
 // We follow the same contract: suspend the TUI, write the three index stages
-// to temp files, run the tool via `sh -c`, wait for exit, then restore.
+// to temp files, substitute the variables in Rust and launch the tool directly,
+// wait for exit, then restore.
 
 use crate::repo::GitRepo;
 use anyhow::{Context, Result};
@@ -181,16 +182,27 @@ fn run_tool_for_file(
 
     let merged_path = workdir.join(file_path);
 
-    // Run via shell so $LOCAL / $BASE / $REMOTE / $MERGED expand from the env vars.
-    let status = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
-        .env("BASE", base_tmp.path())
-        .env("LOCAL", local_tmp.path())
-        .env("REMOTE", remote_tmp.path())
-        .env("MERGED", &merged_path)
+    // Split the command template into program + args, then substitute the
+    // well-known variables so the tool can be launched directly without a shell.
+    // This works on all platforms and handles paths with spaces correctly.
+    let mut parts = shell_words::split(cmd)
+        .with_context(|| format!("failed to parse merge tool command `{cmd}`"))?;
+    if parts.is_empty() {
+        anyhow::bail!("merge tool command is empty");
+    }
+    let substitute = |s: String| -> String {
+        s.replace("$BASE", &base_tmp.path().to_string_lossy())
+            .replace("$LOCAL", &local_tmp.path().to_string_lossy())
+            .replace("$REMOTE", &remote_tmp.path().to_string_lossy())
+            .replace("$MERGED", &merged_path.to_string_lossy())
+    };
+    let prog = substitute(parts.remove(0));
+    let args: Vec<String> = parts.into_iter().map(substitute).collect();
+
+    let status = std::process::Command::new(&prog)
+        .args(&args)
         .status()
-        .context("failed to launch merge tool")?;
+        .with_context(|| format!("failed to launch merge tool `{prog}`"))?;
 
     // Temp files are kept alive (not dropped) until here, ensuring the child
     // can read them for the full duration of its execution.

--- a/src/mergetool.rs
+++ b/src/mergetool.rs
@@ -21,13 +21,12 @@
 //     $BASE (ancestor), and $MERGED (the working-tree file to save the result)
 //   - git runs the cmd through a shell and waits for it to exit
 //
-// We follow the same contract: suspend the TUI, write the three index stages
-// to temp files, substitute the variables in Rust and launch the tool directly,
-// wait for exit, then restore.
+// We follow the same contract: write the three index stages to temp files,
+// substitute the variables in Rust and launch the tool directly, then stage
+// the resolved file. TUI suspend/restore is handled by the caller (main.rs).
 
 use crate::repo::GitRepo;
 use anyhow::{Context, Result};
-use crossterm::{execute, terminal};
 use std::io::Write as _;
 use std::path::Path;
 
@@ -90,17 +89,7 @@ pub fn run_mergetool(repo: &impl GitRepo, conflicting_files: &[String]) -> Resul
         .workdir()
         .ok_or_else(|| anyhow::anyhow!("repository has no working directory"))?;
 
-    // Suspend the TUI before handing the terminal to the merge tool.
-    terminal::disable_raw_mode().context("failed to disable raw mode")?;
-    let _ = execute!(std::io::stdout(), terminal::LeaveAlternateScreen);
-
-    let result = run_for_all_files(&cmd, &workdir, repo, conflicting_files);
-
-    // Restore the TUI unconditionally so the app is never left in a broken state.
-    let _ = terminal::enable_raw_mode();
-    let _ = execute!(std::io::stdout(), terminal::EnterAlternateScreen);
-
-    result?;
+    run_for_all_files(&cmd, &workdir, repo, conflicting_files)?;
     Ok(true)
 }
 


### PR DESCRIPTION
Replace the sh -c approach with shell_words::split + in-process variable substitution for $LOCAL/$BASE/$REMOTE/$MERGED. This fixes launch failures on Windows where sh is not available, and correctly handles tool executable paths that contain spaces.